### PR TITLE
JRS-1304 Visualize.js shouldn't override CSS on third-party page.

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -2009,8 +2009,9 @@ $.fn.datepicker = function(options){
 	}
 
 	/* Append datepicker main container to body if not exist. */
+    // JASPER patch. wrap datepicker by div with class visualizejs for embedding
 	if ($("#"+$.datepicker._mainDivId).length === 0) {
-		$("body").append($.datepicker.dpDiv);
+        $("body").append($("<div class='visualizejs'></div>").append($.datepicker.dpDiv));
 	}
 
 	var otherArgs = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
Wrap datepicker by div with class visualizejs for embedding
